### PR TITLE
Add new state saving system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,7 +1234,7 @@ checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 
 [[package]]
 name = "rsfrac"
-version = "0.1.0-beta.0"
+version = "0.2.0"
 dependencies = [
  "ansi_term",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,7 +1244,9 @@ dependencies = [
  "ratatui",
  "rayon",
  "rug",
+ "serde",
  "strum",
+ "toml",
  "tui-input",
  "tui-markup",
  "tui-scrollview",
@@ -1340,18 +1342,18 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsfrac"
-version = "0.1.0-beta.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Léopold Koprivnik <koprivnik@skwal.net>"]
 description = "The Terminal-Based Fractal Explorer. Rsfrac is your terminal gateway to Mandelbrot, Burning Ship, and Julia."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,9 @@ rand = "0.8.5"
 ratatui = { version = "0.28.1", features = ["all-widgets", "unstable-rendered-line-info"] }
 rayon = "1.10.0"
 rug = "1.26.1"
+serde = { version = "1.0.215", features = ["derive"] }
 strum = "0.26.3"
+toml = "0.8.19"
 tui-input = "0.10.1"
 tui-markup = { version = "0.5.0", features = ["ratatui", "ansi"] }
 tui-scrollview = "=0.4.1"

--- a/src/app/main_loop.rs
+++ b/src/app/main_loop.rs
@@ -56,9 +56,11 @@ impl App {
                     .prioritized_log_messages
                     .get_mut(&job.id)
                     .expect("There was no entry in the prioritized log messages corresponding to the current job.") = format!(
-                    "Screenshot progression: <command {:?}%>",
-                    job.rendered_lines * 100 / job.size.y
-                );
+                        "Screenshot progression:\nline {}/{} (<command {:?}%>)",
+                        job.rendered_lines,
+                        job.size.y,
+                        job.rendered_lines * 100 / job.size.y
+                    );
 
                 for message in job.receiver.try_iter() {
                     match message {

--- a/src/commands/clear.rs
+++ b/src/commands/clear.rs
@@ -1,8 +1,9 @@
 use super::Command;
 use crate::AppState;
 
-pub(crate) fn execute_clear(state: &mut AppState, _args: Vec<&str>) {
+pub(crate) fn execute_clear(state: &mut AppState, _args: Vec<&str>) -> Result<(), String> {
     state.log_messages.clear();
+    Ok(())
 }
 
 pub(crate) const CLEAR: Command = Command {

--- a/src/commands/color.rs
+++ b/src/commands/color.rs
@@ -2,7 +2,7 @@ use super::Command;
 use crate::colors::{get_palette_index_by_name, COLORS};
 use crate::AppState;
 
-pub(crate) fn execute_color(state: &mut AppState, args: Vec<&str>) {
+pub(crate) fn execute_color(state: &mut AppState, args: Vec<&str>) -> Result<(), String> {
     if args.is_empty() {
         state.log_raw(format!(
             "Current colors: <acc {}>\nAvailable colors: {}",
@@ -13,18 +13,17 @@ pub(crate) fn execute_color(state: &mut AppState, args: Vec<&str>) {
                 .collect::<Vec<_>>()
                 .join(", ")
         ));
-        return;
+        return Ok(());
     }
 
-    let palette = get_palette_index_by_name(args[0]);
-    match palette {
-        None => state.log_error(format!("Could not find palette: <red {}>", args[0])),
-        Some(pal) => {
-            state.render_settings.palette_index = pal;
-            state.log_success(format!("Selected color scheme: <acc {}>", COLORS[pal].name,));
-            state.request_repaint();
-        }
-    }
+    let pal = get_palette_index_by_name(args[0])
+        .ok_or(format!("Could not find palette: <red {}>", args[0]))?;
+
+    state.render_settings.palette_index = pal;
+    state.log_success(format!("Selected color scheme: <acc {}>", COLORS[pal].name,));
+    state.request_repaint();
+
+    Ok(())
 }
 
 pub(crate) const COLOR: Command = Command {

--- a/src/commands/load.rs
+++ b/src/commands/load.rs
@@ -1,0 +1,100 @@
+use std::{
+    fs::{self, File},
+    io::Read,
+    sync::Mutex,
+};
+
+use super::Command;
+use crate::{helpers::SavedState, AppState};
+
+pub(crate) fn execute_load(state: &mut AppState, args: Vec<&str>) -> Result<(), String> {
+    static DETECTED_FILES: Mutex<Vec<String>> = Mutex::new(Vec::new());
+    static CURRENT_STATE_FILE_INDEX: Mutex<usize> = Mutex::new(0);
+    if args.is_empty() {
+        *CURRENT_STATE_FILE_INDEX.lock().unwrap() = 0;
+        let mut locked = DETECTED_FILES.lock().unwrap();
+        *locked = fs::read_dir(".")
+            .map_err(|err| format!("Cannot list current working directory: {err}"))?
+            // Only keep sane entries
+            .filter_map(|entry| entry.ok())
+            // Only keep files not directories
+            .filter(|entry| {
+                let ft = entry.file_type();
+                ft.is_ok() && ft.unwrap().is_file()
+            })
+            // Only keep files with valid unicode names
+            .filter_map(|entry| entry.file_name().into_string().ok())
+            // Only keep files ending in .rsf
+            .filter(|filename| filename.ends_with(".rsf"))
+            .collect::<Vec<_>>();
+
+        locked.sort_unstable();
+
+        state.log_info(if locked.is_empty() {
+            "No state file detected in your current working directory.".to_string()
+        } else {
+            format!(
+                "These state files have been detected in your current working directory:\n{}",
+                {
+                    let mut res = String::new();
+                    for (i, filename) in locked.iter().enumerate() {
+                        res += &format!("<acc {i}>: {filename}\n");
+                    }
+                    res.trim().to_string()
+                }
+            )
+        });
+        return Ok(());
+    }
+
+    let mut filename = args[0].to_string();
+
+    if filename == "cycle" {
+        let files_ = DETECTED_FILES.lock().unwrap();
+        if files_.is_empty() {
+            return Err(concat!(
+                "No state file has been found in your current working directory, ",
+                "or the detection has not been performed yet. ",
+                "To detect state files, run <command load> with no arugments."
+            )
+            .to_string());
+        }
+
+        let mut index = CURRENT_STATE_FILE_INDEX.lock().unwrap();
+
+        filename = format!("{index}");
+
+        *index = (*index + 1) % files_.len();
+    }
+
+    // Check if the provided filename can be parsed to an integer
+    if let Ok(num) = filename.parse::<usize>() {
+        let locked = DETECTED_FILES.lock().unwrap();
+        // Check if the detected files vector can be indexed by this integer
+        if let Some(filename_) = locked.get(num) {
+            filename = filename_.to_string();
+        }
+    }
+
+    let mut file = File::open(&filename)
+        .map_err(|err| format!("Could not open file <command {filename}>: {err}"))?;
+
+    let mut str = String::new();
+    file.read_to_string(&mut str)
+        .map_err(|err| format!("The file cannot be read: {err}"))?;
+    let saved: SavedState =
+        toml::from_str(&str).map_err(|err| format!("Could not parse the provided file: {err}"))?;
+    state.apply(saved, &filename);
+    Ok(())
+}
+
+pub(crate) const LOAD: Command = Command {
+    execute: &execute_load,
+    name: "load",
+    accepted_arg_count: &[0, 1],
+    detailed_desc: None,
+    basic_desc: concat!(
+        "Restore the app state (canvas size, position...) from a ",
+        "file that was previously created with the <command save> command."
+    ),
+};

--- a/src/commands/load.rs
+++ b/src/commands/load.rs
@@ -92,7 +92,21 @@ pub(crate) const LOAD: Command = Command {
     execute: &execute_load,
     name: "load",
     accepted_arg_count: &[0, 1],
-    detailed_desc: None,
+    detailed_desc: Some(concat!(
+        "<green Usage: <command [no args]>>\n",
+        "When no args are provided, the state files with the <command rsf> extension in the current ",
+        "working directory will be detected and loaded into a list.\n",
+        "<green Usage: <command [integer]>>\n",
+        "Load the state file corresponding to the provided number in the detection list. ",
+        "Must be ran after <command load>.\n",
+        "<green Usage: <command cycle>>\n",
+        "Cycle through the state files detected with <command load>. ",
+        "After running the command one time, ",
+        "you can rapidly cycle through all the state files using ",
+        "<command Ctrl+R>, which repeats the last command. \n",
+        "<green Usage: <command [file path]>>\n",
+        "Load the state from the specified path.\n",
+    )),
     basic_desc: concat!(
         "Restore the app state (canvas size, position...) from a ",
         "file that was previously created with the <command save> command."

--- a/src/commands/max_iter.rs
+++ b/src/commands/max_iter.rs
@@ -4,7 +4,7 @@ use crate::AppState;
 pub(crate) const MIN_MAX_ITER: i32 = 8;
 pub(crate) const MAX_MAX_ITER: i32 = 10000;
 
-pub(crate) fn execute_max_iter(state: &mut AppState, args: Vec<&str>) {
+pub(crate) fn execute_max_iter(state: &mut AppState, args: Vec<&str>) -> Result<(), String> {
     if let Some(val) = command_increment(
         state,
         state.render_settings.max_iter,
@@ -15,6 +15,7 @@ pub(crate) fn execute_max_iter(state: &mut AppState, args: Vec<&str>) {
         state.render_settings.max_iter = val;
         state.request_redraw();
     }
+    Ok(())
 }
 pub(crate) const MAX_ITER: Command = Command {
     execute: &execute_max_iter,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,18 +7,20 @@ pub(crate) mod color;
 pub(crate) mod command_increment;
 pub(crate) mod frac;
 pub(crate) mod help;
+pub(crate) mod load;
 pub(crate) mod max_iter;
 pub(crate) mod move_dist;
 pub(crate) mod pos;
 pub(crate) mod prec;
 pub(crate) mod quit;
+pub(crate) mod save;
 pub(crate) mod version;
 pub(crate) mod zoom_factor;
 
 /// Represents a rsfrac command.
 pub(crate) struct Command {
     /// Closure to call to execute the command.
-    pub(crate) execute: &'static dyn Fn(&mut AppState, Vec<&str>),
+    pub(crate) execute: &'static dyn Fn(&mut AppState, Vec<&str>) -> Result<(), String>,
     /// The name of the command.
     pub(crate) name: &'static str,
     /// A basic description of the command.
@@ -29,20 +31,26 @@ pub(crate) struct Command {
     pub(crate) accepted_arg_count: &'static [usize],
 }
 
+pub(crate) fn get_commands_list() -> [&'static Command; 14] {
+    [
+        &help::HELP,
+        &quit::QUIT,
+        &clear::CLEAR,
+        &version::VERSION_COMMAND,
+        &save::SAVE,
+        &load::LOAD,
+        &capture::CAPTURE,
+        &pos::POS,
+        &prec::PREC,
+        &max_iter::MAX_ITER,
+        &color::COLOR,
+        &frac::FRAC,
+        &zoom_factor::ZOOM_FACTOR,
+        &move_dist::MOVE_DIST,
+    ]
+}
+
 /// Returns a `HashMap` associating each command's name to itself.
-pub(crate) fn get_commands() -> HashMap<&'static str, &'static Command> {
-    HashMap::from([
-        (help::HELP.name, &help::HELP),
-        (quit::QUIT.name, &quit::QUIT),
-        (clear::CLEAR.name, &clear::CLEAR),
-        (version::VERSION_COMMAND.name, &version::VERSION_COMMAND),
-        (capture::CAPTURE.name, &capture::CAPTURE),
-        (pos::POS.name, &pos::POS),
-        (prec::PREC.name, &prec::PREC),
-        (max_iter::MAX_ITER.name, &max_iter::MAX_ITER),
-        (color::COLOR.name, &color::COLOR),
-        (frac::FRAC.name, &frac::FRAC),
-        (zoom_factor::ZOOM_FACTOR.name, &zoom_factor::ZOOM_FACTOR),
-        (move_dist::MOVE_DIST.name, &move_dist::MOVE_DIST),
-    ])
+pub(crate) fn get_commands_map() -> HashMap<&'static str, &'static Command> {
+    HashMap::from(get_commands_list().map(|command| (command.name, command)))
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -17,10 +17,12 @@ pub(crate) mod save;
 pub(crate) mod version;
 pub(crate) mod zoom_factor;
 
+type CommandClos = &'static dyn Fn(&mut AppState, Vec<&str>) -> Result<(), String>;
+
 /// Represents a rsfrac command.
 pub(crate) struct Command {
     /// Closure to call to execute the command.
-    pub(crate) execute: &'static dyn Fn(&mut AppState, Vec<&str>) -> Result<(), String>,
+    pub(crate) execute: CommandClos,
     /// The name of the command.
     pub(crate) name: &'static str,
     /// A basic description of the command.

--- a/src/commands/move_dist.rs
+++ b/src/commands/move_dist.rs
@@ -4,11 +4,12 @@ use super::{command_increment::command_increment, Command};
 pub(crate) const MIN_MOVE_DIST: i32 = 1;
 pub(crate) const MAX_MOVE_DIST: i32 = 100;
 
-pub(crate) fn execute_move_dist(state: &mut AppState, args: Vec<&str>) {
+pub(crate) fn execute_move_dist(state: &mut AppState, args: Vec<&str>) -> Result<(), String> {
     if let Some(val) = command_increment(state, state.move_dist, args, MIN_MOVE_DIST, MAX_MOVE_DIST)
     {
         state.move_dist = val;
     }
+    Ok(())
 }
 pub(crate) const MOVE_DIST: Command = Command {
     execute: &execute_move_dist,

--- a/src/commands/pos.rs
+++ b/src/commands/pos.rs
@@ -2,7 +2,7 @@ use super::Command;
 use crate::AppState;
 use rug::{Assign, Float};
 
-pub(crate) fn execute_pos(state: &mut AppState, args: Vec<&str>) {
+pub(crate) fn execute_pos(state: &mut AppState, args: Vec<&str>) -> Result<(), String> {
     // If no args are provided, show the current positino
     if args.is_empty() {
         state.log_info_title(
@@ -13,7 +13,7 @@ pub(crate) fn execute_pos(state: &mut AppState, args: Vec<&str>) {
                 state.render_settings.pos.imag()
             ),
         );
-        return;
+        return Ok(());
     }
     // If args were provided, there must be exactly 2 args.
     let real = args[0];
@@ -25,8 +25,9 @@ pub(crate) fn execute_pos(state: &mut AppState, args: Vec<&str>) {
     let parsed_imag = Float::parse(imag);
 
     if (set_real && parsed_real.is_err()) || (set_imag && parsed_imag.is_err()) {
-        state.log_error("The provided real and imaginary parts must be valid floats or <acc ~>.");
-        return;
+        return Err(
+            "The provided real and imaginary parts must be valid floats or <acc ~>.".to_string(),
+        );
     }
 
     if set_real {
@@ -44,6 +45,7 @@ pub(crate) fn execute_pos(state: &mut AppState, args: Vec<&str>) {
             .assign(parsed_imag.unwrap());
     }
     state.request_redraw();
+    Ok(())
 }
 
 pub(crate) const POS: Command = Command {

--- a/src/commands/prec.rs
+++ b/src/commands/prec.rs
@@ -4,7 +4,7 @@ use crate::AppState;
 pub(crate) const MIN_DECIMAL_PREC: u32 = 8;
 pub(crate) const MAX_DECIMAL_PREC: u32 = 10000;
 
-pub(crate) fn execute_prec(state: &mut AppState, args: Vec<&str>) {
+pub(crate) fn execute_prec(state: &mut AppState, args: Vec<&str>) -> Result<(), String> {
     if let Some(val) = command_increment(
         state,
         state.render_settings.prec,
@@ -12,9 +12,9 @@ pub(crate) fn execute_prec(state: &mut AppState, args: Vec<&str>) {
         MIN_DECIMAL_PREC,
         MAX_DECIMAL_PREC,
     ) {
-        state.render_settings.prec = val;
-        state.request_redraw();
+        state.set_decimal_prec(val);
     }
+    Ok(())
 }
 pub(crate) const PREC: Command = Command {
     execute: &execute_prec,

--- a/src/commands/quit.rs
+++ b/src/commands/quit.rs
@@ -1,8 +1,9 @@
 use super::Command;
 use crate::AppState;
 
-pub(crate) fn execute_quit(state: &mut AppState, _args: Vec<&str>) {
+pub(crate) fn execute_quit(state: &mut AppState, _args: Vec<&str>) -> Result<(), String> {
     state.quit = true;
+    Ok(())
 }
 pub(crate) const QUIT: Command = Command {
     execute: &execute_quit,

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -1,0 +1,38 @@
+use std::{fs::File, io::Write};
+
+use chrono::Local;
+
+use super::Command;
+use crate::{helpers::SavedState, AppState};
+
+pub(crate) fn execute_save(state: &mut AppState, args: Vec<&str>) -> Result<(), String> {
+    let filename = if args.is_empty() {
+        format!(
+            "{} {}.rsf",
+            Local::now().format("%F %H-%M-%S"),
+            state.render_settings.get_frac_obj().name
+        )
+    } else {
+        args[0].to_string() + ".rsf"
+    };
+
+    let saved_state = SavedState::from(&*state);
+    let str = toml::to_string_pretty(&saved_state)
+        .map_err(|err| format!("Could not save the current state: {err}"))?;
+
+    let mut file = File::create(&filename)
+        .map_err(|err| format!("Could not create <command {filename}>: {err}"))?;
+
+    file.write(str.as_bytes())
+        .map_err(|err| format!("Could not write file: {err}"))?;
+    state.log_success(format!("State successfully saved as <command {filename}>."));
+    Ok(())
+}
+
+pub(crate) const SAVE: Command = Command {
+    execute: &execute_save,
+    name: "save",
+    accepted_arg_count: &[0, 1],
+    detailed_desc: None,
+    basic_desc: "Save the current application state to a file that can be loaded back later with the <command load> command.",
+};

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -33,6 +33,11 @@ pub(crate) const SAVE: Command = Command {
     execute: &execute_save,
     name: "save",
     accepted_arg_count: &[0, 1],
-    detailed_desc: None,
+    detailed_desc: Some(concat!(
+        "<green Usage: <command [file path]>>\n",
+        "Save the current state using the provided file path.\n",
+        "<green Usage: <command [no args]>>\n",
+        "Save the current state using a generic name.\n",
+    )),
     basic_desc: "Save the current application state to a file that can be loaded back later with the <command load> command.",
 };

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -1,11 +1,12 @@
 use super::Command;
 use crate::{AppState, VERSION};
 
-pub(crate) fn execute_version(state: &mut AppState, _args: Vec<&str>) {
+pub(crate) fn execute_version(state: &mut AppState, _args: Vec<&str>) -> Result<(), String> {
     state.log_info_title(
         "Rsfrac version",
         format!("Rsfrac is running version <acc {}>", VERSION),
-    )
+    );
+    Ok(())
 }
 
 pub(crate) const VERSION_COMMAND: Command = Command {

--- a/src/commands/zoom_factor.rs
+++ b/src/commands/zoom_factor.rs
@@ -1,7 +1,7 @@
 use super::Command;
 use crate::AppState;
 
-pub(crate) fn execute_zoom_factor(state: &mut AppState, args: Vec<&str>) {
+pub(crate) fn execute_zoom_factor(state: &mut AppState, args: Vec<&str>) -> Result<(), String> {
     // If no args are provided, show the current positino
     if args.is_empty() {
         state.log_info_title(
@@ -11,22 +11,22 @@ pub(crate) fn execute_zoom_factor(state: &mut AppState, args: Vec<&str>) {
                 state.scaling_factor
             ),
         );
-        return;
+        return Ok(());
     }
 
-    if let Ok(new_value) = args[0].parse::<i32>() {
-        if !(1..=500).contains(&new_value) {
-            state.log_error("Please, provide a value between 1 and 500.");
-            return;
-        }
+    let new_value = args[0]
+        .parse::<i32>()
+        .map_err(|err| format!("Please provide a valid integer: {err}"))?;
 
-        state.scaling_factor = new_value;
-        state.log_success(format!(
-            "Scaling factor successfully set to <acc {new_value}%>"
-        ));
-    } else {
-        state.log_error("Please, provide a valid integer.")
+    if !(1..=500).contains(&new_value) {
+        return Err("Please, provide a value between 1 and 500.".to_string());
     }
+
+    state.scaling_factor = new_value;
+    state.log_success(format!(
+        "Scaling factor successfully set to <acc {new_value}%>"
+    ));
+    Ok(())
 }
 
 pub(crate) const ZOOM_FACTOR: Command = Command {

--- a/src/components/canvas.rs
+++ b/src/components/canvas.rs
@@ -46,13 +46,8 @@ impl<'a> Canvas<'a> {
     }
 
     pub(crate) fn handle_mouse_event(state: &mut AppState, event: MouseEvent) {
-        // If the canvas is not already focused, only take focus
-        if state.focused != Focus::Canvas {
-            state.focused = Focus::Canvas;
-            return;
-        }
+        state.focused = Focus::Canvas;
 
-        // If the canvas is already focused, handle the event
         // first, convert the key press position to canvas coordinates
 
         let canvas_pos = state
@@ -175,13 +170,6 @@ impl<'a> Canvas<'a> {
             KeyCode::Char('v') => {
                 state.render_settings.void_fill_index =
                     (state.render_settings.void_fill_index + 1) % void_fills().len();
-                state.log_info_title(
-                    "Void Fill",
-                    format!(
-                        "Void fill is now: <acc {}>",
-                        void_fills()[state.render_settings.void_fill_index]
-                    ),
-                );
                 state.request_repaint();
                 return;
             }
@@ -211,6 +199,13 @@ impl<'a> Widget for Canvas<'a> {
         let canvas_block = Block::bordered()
             .style(border_style)
             .title_bottom(
+                Line::from(format!(
+                    "VoidFill[{}]",
+                    void_fills()[self.state.render_settings.void_fill_index]
+                ))
+                .right_aligned(),
+            )
+            .title_bottom(
                 Line::from(format!("Pts[{}]", self.state.render_settings.point_count()))
                     .left_aligned(),
             )
@@ -219,15 +214,9 @@ impl<'a> Widget for Canvas<'a> {
             )
             .title_bottom(
                 Line::from(format!(
-                    "PalOffset[{}]",
+                    "Colors[{}+{}]",
+                    self.state.render_settings.get_palette().name,
                     self.state.render_settings.color_scheme_offset
-                ))
-                .right_aligned(),
-            )
-            .title_bottom(
-                Line::from(format!(
-                    "Colors[{}]",
-                    self.state.render_settings.get_palette().name
                 ))
                 .right_aligned(),
             )

--- a/src/frac_logic/fractal_logic.rs
+++ b/src/frac_logic/fractal_logic.rs
@@ -125,6 +125,11 @@ impl RenderSettings {
         )
     }
 
+    /// Set the cell size so that the total width of the canvas is set to the specified size.
+    pub(crate) fn set_width(&mut self, width: Float) {
+        self.cell_size = width / self.canvas_size.x;
+    }
+
     /// Set the cell size so that the total width of the canvas is 4 on the real axis.
     pub(crate) fn reset_cell_size(&mut self) {
         self.cell_size = self.get_default_cell_size();

--- a/src/fractals/mod.rs
+++ b/src/fractals/mod.rs
@@ -27,13 +27,11 @@ pub(crate) struct Fractal {
     pub(crate) default_pos: (f64, f64),
 }
 
-impl RenderSettings {
-    /// Returns the index of a fractal which name matches, or `None`.
-    pub(crate) fn get_frac_index_by_name(&self, name: &str) -> Option<usize> {
-        FRACTALS
-            .iter()
-            .position(|f| f.name.to_lowercase().starts_with(&name.to_lowercase()))
-    }
+/// Returns the index of a fractal which name matches, or `None`.
+pub(crate) fn get_frac_index_by_name(name: &str) -> Option<usize> {
+    FRACTALS
+        .iter()
+        .position(|f| f.name.to_lowercase().starts_with(&name.to_lowercase()))
 }
 
 pub(crate) const FRACTALS: &[Fractal] = &[MANDELBROT, BURNING_SHIP, JULIA];

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,5 +1,6 @@
 mod chunks;
 mod focus;
+mod saved_state;
 mod vec2;
 mod void_fills;
 mod zoom_direction;
@@ -7,6 +8,7 @@ mod zoom_direction;
 pub(crate) mod markup;
 pub(crate) use chunks::Chunks;
 pub(crate) use focus::Focus;
+pub(crate) use saved_state::SavedState;
 pub(crate) use vec2::Vec2;
 pub(crate) use void_fills::{void_fills, VoidFill};
 pub(crate) use zoom_direction::ZoomDirection;

--- a/src/helpers/saved_state.rs
+++ b/src/helpers/saved_state.rs
@@ -1,0 +1,32 @@
+use crate::AppState;
+use serde::{Deserialize, Serialize};
+
+use super::{void_fills, VoidFill};
+
+/// Describes the state data that can be saved to a rsf file.
+#[derive(Serialize, Deserialize)]
+pub(crate) struct SavedState {
+    pub(crate) frac_name: Option<String>,
+    pub(crate) color_palette_name: Option<String>,
+    pub(crate) palette_offset: Option<i32>,
+    pub(crate) pos: Option<String>,
+    pub(crate) complex_width: Option<String>,
+    pub(crate) precision: Option<u32>,
+    pub(crate) max_iter: Option<i32>,
+    pub(crate) void_fill: Option<VoidFill>,
+}
+
+impl From<&AppState> for SavedState {
+    fn from(state: &AppState) -> Self {
+        Self {
+            frac_name: Some(state.render_settings.get_frac_obj().name.to_string()),
+            color_palette_name: Some(state.render_settings.get_palette().name.to_string()),
+            palette_offset: Some(state.render_settings.color_scheme_offset),
+            pos: Some(state.render_settings.pos.to_string()),
+            complex_width: Some(state.render_settings.get_plane_wid().to_string()),
+            max_iter: Some(state.render_settings.max_iter),
+            precision: Some(state.render_settings.prec),
+            void_fill: Some(void_fills()[state.render_settings.void_fill_index].clone()),
+        }
+    }
+}

--- a/src/helpers/void_fills.rs
+++ b/src/helpers/void_fills.rs
@@ -1,6 +1,7 @@
+use serde::{Deserialize, Serialize};
 use strum::{Display, EnumIter, IntoEnumIterator};
 
-#[derive(EnumIter, Debug, Display)]
+#[derive(PartialEq, EnumIter, Debug, Display, Clone, Deserialize, Serialize)]
 pub(crate) enum VoidFill {
     Transparent,
     Black,

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -101,10 +101,6 @@ impl AppState {
     }
     /// Creates a new error log message with the provided title and message.
     pub(crate) fn log_error_title(&mut self, title: impl Into<String>, message: impl Into<String>) {
-        self.log_raw(format!(
-            "<bgred  {} >\n<red {}>",
-            title.into(),
-            message.into()
-        ))
+        self.log_raw(format!("<bgred  {} >\n{}", title.into(), message.into()))
     }
 }


### PR DESCRIPTION
- add `save` command
- add `load` command
- add `serde` dependency
- add `toml` dependency
- update screenshot progression message
- move `get_fractal_index_by_name` out of `RenderSettings` as not needed
- add `^R` shortcut on command input to repeat the last command
- add `AppState.apply` to apply a `SavedState` to the current app state.
- add better command error handling and signaling
- split `get_commands` in `get_commands_list` and `get_commands_map`
- fix `prec` command not updating precision of already existing values
- handle canvas clicks even when not focused at first
- remove log messages displayed when changing `VoidFill` method
- add `RenderSettings.set_width`
- change message color when using `AppState.log_error*()`