### PR TITLE
Add missing fractal shaders &m

### DIFF
--- a/src/commands/frac.rs
+++ b/src/commands/frac.rs
@@ -1,5 +1,3 @@
-use futures::executor;
-
 use super::Command;
 use crate::{
     fractals::{get_frac_index_by_name, FRACTALS},
@@ -43,14 +41,11 @@ pub(crate) fn execute_frac(state: &mut AppState, args: Vec<&str>) -> Result<(), 
         state.log_info_title(frac_obj.name, frac_obj.details);
     } else {
         state.request_redraw();
-        state.render_settings.frac_index = frac_i;
-        state.log_success(format!("Successfully selected fractal: <acc {frac_name}>."));
-        if let Err(err) = executor::block_on(state.render_settings.update_fractal_shader(None)) {
-            state.render_settings.use_gpu = false;
-            return Err(format!(
-                "Disabling GPU mode because fractal shader could not be loaded: {err}"
-            ));
-        };
+        state.render_settings.select_fractal(frac_i)?;
+        state.log_success(format!(
+            "Successfully selected fractal: <acc {}>.",
+            state.render_settings.get_frac_obj().name
+        ));
     }
     Ok(())
 }

--- a/src/commands/gpu.rs
+++ b/src/commands/gpu.rs
@@ -14,8 +14,8 @@ pub(crate) fn execute_gpu(state: &mut AppState, _args: Vec<&str>) -> Result<(), 
             }
             Err(err) => state.log_error(format!("GPU mode could not be initialized: {err}")),
         };
-        state.request_redraw();
     }
+    state.request_redraw();
     Ok(())
 }
 pub(crate) const GPU: Command = Command {

--- a/src/components/canvas.rs
+++ b/src/components/canvas.rs
@@ -189,10 +189,7 @@ impl<'a> Canvas<'a> {
             KeyCode::Char('o') => state.increment_max_iter(10),
             // Decrement the maximum divergence
             KeyCode::Char('y') => state.increment_max_iter(-10),
-            _ => {
-                // Return from the function to avoid setting redraw_canvas
-                return;
-            }
+            _ => {}
         }
     }
 }

--- a/src/components/canvas.rs
+++ b/src/components/canvas.rs
@@ -1,6 +1,5 @@
 //! Contains the `Canvas` widget.
 
-use futures::executor;
 use ratatui::{
     buffer::Buffer,
     crossterm::event::{KeyCode, MouseButton, MouseEvent, MouseEventKind},
@@ -81,6 +80,7 @@ impl<'a> Canvas<'a> {
                         state.render_settings.prec,
                         &state.render_settings.cell_size * state.move_dist,
                     ));
+                state.request_redraw();
             }
             // When L is pressed move the position of the canvas
             // to the right by n times the cell size.
@@ -93,6 +93,7 @@ impl<'a> Canvas<'a> {
                         state.render_settings.prec,
                         &state.render_settings.cell_size * state.move_dist,
                     ));
+                state.request_redraw();
             }
             // When J is pressed move the position of the canvas
             // down by n times the cell size.
@@ -105,6 +106,7 @@ impl<'a> Canvas<'a> {
                         state.render_settings.prec,
                         &state.render_settings.cell_size * state.move_dist,
                     ));
+                state.request_redraw();
             }
             // When K is pressed move the position of the canvas
             // up by n times the cell size.
@@ -117,43 +119,47 @@ impl<'a> Canvas<'a> {
                         state.render_settings.prec,
                         &state.render_settings.cell_size * state.move_dist,
                     ));
+                state.request_redraw();
             }
             // When S is pressed increase the cell size, which will zoom out of the canvas
-            KeyCode::Char('s') => state.zoom(ZoomDirection::Out),
+            KeyCode::Char('s') => {
+                state.zoom(ZoomDirection::Out);
+                state.request_redraw();
+            }
             // When D is pressed decrease the cell size, which will zoom into the canvas
-            KeyCode::Char('d') => state.zoom(ZoomDirection::In),
+            KeyCode::Char('d') => {
+                state.zoom(ZoomDirection::In);
+                state.request_redraw();
+            }
             // decrease the decimal precision
             KeyCode::Char('u') => {
                 state.increment_decimal_prec(-10);
+                state.request_redraw();
             }
             // increase the decimal precision
             KeyCode::Char('i') => {
                 state.increment_decimal_prec(10);
+                state.request_redraw();
             }
             // reset the position to the origin and the cell size.
             KeyCode::Char('r') => {
                 state.render_settings.reset_cell_size();
                 state.render_settings.reset_pos();
+                state.request_redraw();
             }
             // Increment the selected frac index
             KeyCode::Char('f') => {
-                state.render_settings.frac_index =
-                    (state.render_settings.frac_index + 1) % FRACTALS.len();
-                if let Err(err) =
-                    executor::block_on(state.render_settings.update_fractal_shader(None))
-                {
-                    state.render_settings.use_gpu = false;
-                    state.log_error(format!(
-                        "Disabling GPU mode because fractal shader could not be loaded: {err}"
-                    ));
-                };
+                let frac_i = (state.render_settings.frac_index + 1) % FRACTALS.len();
+                if let Err(err) = state.render_settings.select_fractal(frac_i) {
+                    state.log_error(err);
+                }
+                state.request_redraw();
             }
             // Increment the color palette index
             KeyCode::Char('c') => {
                 state.render_settings.palette_index =
                     (state.render_settings.palette_index + 1) % colors::COLORS.len();
                 state.request_repaint();
-                return;
             }
             // Todo: remove duplication for + and -
             // Increment color scheme offset
@@ -165,7 +171,6 @@ impl<'a> Canvas<'a> {
                         % state.render_settings.get_palette().colors.len() as i32;
 
                 state.request_repaint();
-                return;
             }
             // Increment color scheme offset
             KeyCode::Char('+') => {
@@ -173,14 +178,12 @@ impl<'a> Canvas<'a> {
                     (state.render_settings.color_scheme_offset + 1)
                         % state.render_settings.get_palette().colors.len() as i32;
                 state.request_repaint();
-                return;
             }
             // Cycle through the void fills
             KeyCode::Char('v') => {
                 state.render_settings.void_fill_index =
                     (state.render_settings.void_fill_index + 1) % void_fills().len();
                 state.request_repaint();
-                return;
             }
             // Increment the maximum divergence
             KeyCode::Char('o') => state.increment_max_iter(10),
@@ -191,9 +194,6 @@ impl<'a> Canvas<'a> {
                 return;
             }
         }
-
-        // For now, all events need to redraw the canvas.
-        state.request_redraw();
     }
 }
 impl<'a> Widget for Canvas<'a> {

--- a/src/frac_logic/gpu.rs
+++ b/src/frac_logic/gpu.rs
@@ -96,6 +96,8 @@ impl RenderSettings {
         let cs_descriptor = match self.get_frac_obj().name.to_lowercase().as_ref() {
             // TODO: implement other fractal shaders
             "mandelbrot" => wgpu::include_wgsl!("shaders/mandelbrot.wgsl"),
+            "burningship" => wgpu::include_wgsl!("shaders/burning_ship.wgsl"),
+            "julia" => wgpu::include_wgsl!("shaders/julia.wgsl"),
             _ => {
                 if let Some(sender) = sender {
                     sender

--- a/src/frac_logic/shaders/burning_ship.wgsl
+++ b/src/frac_logic/shaders/burning_ship.wgsl
@@ -1,1 +1,40 @@
-// TODO
+struct Params {
+    max_iter: i32,
+    width_px: i32,
+}
+
+
+@group(0) @binding(0) var<storage, read> input_buf: array<vec2<f32>>; 
+@group(0) @binding(1) var<storage, read_write> output_buf: array<i32>; 
+@group(0) @binding(2) var<uniform> params: Params; 
+
+
+fn bship_iterations(real: f32, imag: f32) -> i32 {
+    var iter: i32 = 0i;
+    var z: vec2<f32> = vec2<f32>(0f, 0f);
+
+    while length(z) < 4f && iter < params.max_iter {
+        z = vec2<f32>(
+            pow(z.x, 2f) - pow(z.y, 2f) + real,
+            2f * abs(z.x) * abs(z.y) + imag
+        );
+        iter = iter + 1i;
+    }
+    if iter == params.max_iter {
+        return -1i;
+    }
+    return iter;
+}
+
+@compute
+@workgroup_size(1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let x: u32 = global_id.x;
+    let y: u32 = global_id.y;
+    let index = y * u32(params.width_px) + x;
+    let point: vec2<f32> = input_buf[index];
+    // *-1 to invert the y and x axis artificially
+    output_buf[index] = bship_iterations(point.x * -1f, point.y * -1f);
+}
+
+

--- a/src/frac_logic/shaders/julia.wgsl
+++ b/src/frac_logic/shaders/julia.wgsl
@@ -1,1 +1,43 @@
-// TODO
+struct Params {
+    max_iter: i32,
+    width_px: i32,
+}
+
+
+@group(0) @binding(0) var<storage, read> input_buf: array<vec2<f32>>; 
+@group(0) @binding(1) var<storage, read_write> output_buf: array<i32>; 
+@group(0) @binding(2) var<uniform> params: Params; 
+
+
+fn julia_iterations(real: f32, imag: f32) -> i32 {
+    var iter: i32 = 0i;
+    var z: vec2<f32> = vec2<f32>(real, imag);
+
+    while length(z) < 4f && iter < params.max_iter {
+        // z = vec2<f32>(
+        //     pow(z.x, 2f) - pow(z.y, 2f),
+        //     2f * z.x * z.y + imag
+        // );
+        z = vec2<f32>(
+            pow(z.x, 2f) - pow(z.y, 2f) - 1,
+            2f * z.x * z.y
+        );
+        iter = iter + 1i;
+    }
+    if iter == params.max_iter {
+        return -1i;
+    }
+    return iter;
+}
+
+@compute
+@workgroup_size(1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let x: u32 = global_id.x;
+    let y: u32 = global_id.y;
+    let index = y * u32(params.width_px) + x;
+    let point: vec2<f32> = input_buf[index];
+    output_buf[index] = julia_iterations(point.x, point.y);
+}
+
+


### PR DESCRIPTION
- Add missing fractal shader for: `julia` and `burning_ship`
- fix: crash when selecting new fractal with GPU mode disabled.
- Remove some code duplication
- Fix bug: terminal not redrawn when disabling GPU mode.
- Add `RenderSettings.select_fractal(frac_i: i32)` method to reload GPU pipeline when changing selected fractal.