### PR TITLE
Improve GPU rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,20 @@ name = "bytemuck"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ include = [
 
 [dependencies]
 ansi_term = "0.12.1"
-bytemuck = "1.20.0"
+bytemuck = { version = "1.20.0", features = ["derive"] }
 chrono = "0.4.38"
 flume = "0.11.1"
 futures = "0.3.31"

--- a/src/commands/capture.rs
+++ b/src/commands/capture.rs
@@ -21,11 +21,14 @@ pub(crate) fn execute_capture(state: &mut AppState, args: Vec<&str>) -> Result<(
                 "The provided width could not be parsed, make sure to enter a valid integer: {err}"
             )
         })?;
-        let parsed_height = height.parse().map_err(|err| format!("The provided height could not be parsed, make sure to enter a valid integer: {err}"))?;
 
-        if parsed_height < 16 || parsed_width < 16 {
+        let parsed_height: i32 = height.parse().map_err(|err| format!("The provided height could not be parsed, make sure to enter a valid integer: {err}"))?;
+
+        let size_range = 16..u16::MAX as i32 + 1;
+
+        if !size_range.contains(&parsed_height) || !size_range.contains(&parsed_width) {
             return Err(
-                "The screenshot must be at least 16 pixels in width and height.".to_string(),
+                "The screenshot must be at least 16 and at most 65535 pixels in width and height.".to_string(),
             );
         }
 

--- a/src/commands/capture.rs
+++ b/src/commands/capture.rs
@@ -28,7 +28,8 @@ pub(crate) fn execute_capture(state: &mut AppState, args: Vec<&str>) -> Result<(
 
         if !size_range.contains(&parsed_height) || !size_range.contains(&parsed_width) {
             return Err(
-                "The screenshot must be at least 16 and at most 65535 pixels in width and height.".to_string(),
+                "The screenshot must be at least 16 and at most 65535 pixels in width and height."
+                    .to_string(),
             );
         }
 

--- a/src/components/log_panel.rs
+++ b/src/components/log_panel.rs
@@ -119,9 +119,9 @@ impl<'a> Widget for LogPanel<'a> {
             lines.push((para, para_area));
         }
 
-        // height - 1 to ignore the blank space for the last separator
-        // which will not be displayed
-        let size = Size::new(para_width, scrollable_height.saturating_sub(1));
+        // height + 5 to give some space at the bottom in case a prioritized
+        // message changes rapidly of length
+        let size = Size::new(para_width, scrollable_height + 5);
 
         // ATTENTION
         // After countless hours of debugging, I realized that when

--- a/src/frac_logic/gpu.rs
+++ b/src/frac_logic/gpu.rs
@@ -473,7 +473,9 @@ impl RenderSettings {
             staging_buffer.unmap();
         }
 
-        tracker.send("Saving image to file... The application will be blocked during the time of writing.")?;
+        tracker.send(
+            "Saving image to file... The application will be blocked during the time of writing.",
+        )?;
         tracker.scroll_logs();
         Ok(result)
     }

--- a/src/frac_logic/shaders/burning_ship.wgsl
+++ b/src/frac_logic/shaders/burning_ship.wgsl
@@ -1,22 +1,50 @@
 struct Params {
     max_iter: i32,
     width_px: i32,
+    height_px: i32,
+    pos_real: f32,
+    pos_imag: f32,
+    cell_size: f32,
+    y_offset: i32,
 }
 
 
-@group(0) @binding(0) var<storage, read> input_buf: array<vec2<f32>>; 
-@group(0) @binding(1) var<storage, read_write> output_buf: array<i32>; 
-@group(0) @binding(2) var<uniform> params: Params; 
+@group(0) @binding(0) var<storage, read_write> output_buf: array<i32>; 
+@group(0) @binding(1) var<uniform> params: Params; 
+
+fn coords_to_c(x_: u32, y_: u32) -> vec2<f32> {
+    let x = -params.width_px / 2 + i32(x_);
+    let y = -params.height_px / 2 + i32(y_) + params.y_offset;
+    return vec2(
+        f32(x) * params.cell_size + params.pos_real,
+        f32(y) * params.cell_size + params.pos_imag,
+    );
+}
+
+@compute
+@workgroup_size(1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let x: u32 = global_id.x;
+    let y: u32 = global_id.y;
 
 
-fn bship_iterations(real: f32, imag: f32) -> i32 {
+    let point = coords_to_c(x, y);
+    let index = y * u32(params.width_px) + x;
+
+    output_buf[index] = iterations(point);
+}
+
+
+// ============= Everything above this line should be the same in all fractal shaders
+
+fn iterations(point: vec2<f32>) -> i32 {
     var iter: i32 = 0i;
     var z: vec2<f32> = vec2<f32>(0f, 0f);
 
     while length(z) < 4f && iter < params.max_iter {
         z = vec2<f32>(
-            pow(z.x, 2f) - pow(z.y, 2f) + real,
-            2f * abs(z.x) * abs(z.y) + imag
+            pow(z.x, 2f) - pow(z.y, 2f) - point.x,
+            2f * abs(z.x) * abs(z.y) - point.y
         );
         iter = iter + 1i;
     }
@@ -25,16 +53,3 @@ fn bship_iterations(real: f32, imag: f32) -> i32 {
     }
     return iter;
 }
-
-@compute
-@workgroup_size(1)
-fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
-    let x: u32 = global_id.x;
-    let y: u32 = global_id.y;
-    let index = y * u32(params.width_px) + x;
-    let point: vec2<f32> = input_buf[index];
-    // *-1 to invert the y and x axis artificially
-    output_buf[index] = bship_iterations(point.x * -1f, point.y * -1f);
-}
-
-

--- a/src/frac_logic/shaders/julia.wgsl
+++ b/src/frac_logic/shaders/julia.wgsl
@@ -1,17 +1,46 @@
 struct Params {
     max_iter: i32,
     width_px: i32,
+    height_px: i32,
+    pos_real: f32,
+    pos_imag: f32,
+    cell_size: f32,
+    y_offset: i32,
 }
 
 
-@group(0) @binding(0) var<storage, read> input_buf: array<vec2<f32>>; 
-@group(0) @binding(1) var<storage, read_write> output_buf: array<i32>; 
-@group(0) @binding(2) var<uniform> params: Params; 
+@group(0) @binding(0) var<storage, read_write> output_buf: array<i32>; 
+@group(0) @binding(1) var<uniform> params: Params; 
+
+fn coords_to_c(x_: u32, y_: u32) -> vec2<f32> {
+    let x = -params.width_px / 2 + i32(x_);
+    let y = -params.height_px / 2 + i32(y_) + params.y_offset;
+    return vec2(
+        f32(x) * params.cell_size + params.pos_real,
+        f32(y) * params.cell_size + params.pos_imag,
+    );
+}
+
+@compute
+@workgroup_size(1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let x: u32 = global_id.x;
+    let y: u32 = global_id.y;
 
 
-fn julia_iterations(real: f32, imag: f32) -> i32 {
+    let point = coords_to_c(x, y);
+    let index = y * u32(params.width_px) + x;
+
+    output_buf[index] = iterations(point);
+}
+
+
+// ============= Everything above this line should be the same in all fractal shaders
+
+
+fn iterations(point: vec2<f32>) -> i32 {
+    var z = point;
     var iter: i32 = 0i;
-    var z: vec2<f32> = vec2<f32>(real, imag);
 
     while length(z) < 4f && iter < params.max_iter {
         // z = vec2<f32>(
@@ -29,15 +58,4 @@ fn julia_iterations(real: f32, imag: f32) -> i32 {
     }
     return iter;
 }
-
-@compute
-@workgroup_size(1)
-fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
-    let x: u32 = global_id.x;
-    let y: u32 = global_id.y;
-    let index = y * u32(params.width_px) + x;
-    let point: vec2<f32> = input_buf[index];
-    output_buf[index] = julia_iterations(point.x, point.y);
-}
-
 

--- a/src/frac_logic/shaders/mandelbrot.wgsl
+++ b/src/frac_logic/shaders/mandelbrot.wgsl
@@ -1,22 +1,50 @@
 struct Params {
     max_iter: i32,
     width_px: i32,
+    height_px: i32,
+    pos_real: f32,
+    pos_imag: f32,
+    cell_size: f32,
+    y_offset: i32,
 }
 
 
-@group(0) @binding(0) var<storage, read> input_buf: array<vec2<f32>>; 
-@group(0) @binding(1) var<storage, read_write> output_buf: array<i32>; 
-@group(0) @binding(2) var<uniform> params: Params; 
+@group(0) @binding(0) var<storage, read_write> output_buf: array<i32>; 
+@group(0) @binding(1) var<uniform> params: Params; 
+
+fn coords_to_c(x_: u32, y_: u32) -> vec2<f32> {
+    let x = -params.width_px / 2 + i32(x_);
+    let y = -params.height_px / 2 + i32(y_) + params.y_offset;
+    return vec2(
+        f32(x) * params.cell_size + params.pos_real,
+        f32(y) * params.cell_size + params.pos_imag,
+    );
+}
+
+@compute
+@workgroup_size(1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let x: u32 = global_id.x;
+    let y: u32 = global_id.y;
 
 
-fn mandelbrot_iterations(real: f32, imag: f32) -> i32 {
+    let point = coords_to_c(x, y);
+    let index = y * u32(params.width_px) + x;
+
+    output_buf[index] = iterations(point);
+}
+
+
+// ============= Everything above this line should be the same in all fractal shaders
+
+fn iterations(point: vec2<f32>) -> i32 {
     var iter: i32 = 0i;
     var z: vec2<f32> = vec2<f32>(0f, 0f);
 
     while length(z) < 2f && iter < params.max_iter {
         z = vec2<f32>(
-            z.x * z.x - z.y * z.y + real,
-            2f * z.x * z.y + imag
+            z.x * z.x - z.y * z.y + point.x,
+            2f * z.x * z.y + point.y
         );
         iter = iter + 1i;
     }
@@ -25,15 +53,4 @@ fn mandelbrot_iterations(real: f32, imag: f32) -> i32 {
     }
     return iter;
 }
-
-@compute
-@workgroup_size(1)
-fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
-    let x: u32 = global_id.x;
-    let y: u32 = global_id.y;
-    let index = y * u32(params.width_px) + x;
-    let point: vec2<f32> = input_buf[index];
-    output_buf[index] = mandelbrot_iterations(point.x, point.y);
-}
-
 


### PR DESCRIPTION
- Perform complex position calculation in parallel in the fractal shader instead of in the render pipeline. This multiplied the rendering speed by >10!!!
- Improve shader code (a shame we don't have an `include` statement in wgsl)
- Improve screenshot progress reporting in GPU mode.
- Add some space at the bottom of the logs panel for smoother output.
- Limit screenshot size to `65535`
- Change screenshot format to WebP
- Improve error reporting.
- Create new `SlaveMessage` : `ScrollLogs`
- Wait one terminal render before saving screenshots for progress messages are not shown if we directly else.