### PR TITLE
Add command aliases and custom mandelbrot constant

### DIFF
--- a/src/app_state/click_modes.rs
+++ b/src/app_state/click_modes.rs
@@ -5,6 +5,7 @@ pub(crate) enum ClickMode {
     ZoomIn,
     ZoomOut,
     JuliaConstant,
+    MandelConstant,
     Move,
 }
 
@@ -19,13 +20,16 @@ impl ClickMode {
     }
 
     pub fn from(str_: &str) -> Option<Self> {
-        Some(match str_.to_lowercase().as_str() {
-            "zoomin" => Self::ZoomIn,
-            "zoomout" => Self::ZoomOut,
-            "move" => Self::Move,
-            "juliaconstant" => Self::JuliaConstant,
-            _ => return None,
-        })
+        [
+            ("zoomin", Self::ZoomIn),
+            ("zoomout", Self::ZoomOut),
+            ("move", Self::Move),
+            ("juliaconstant", Self::JuliaConstant),
+            ("mandelconstant", Self::MandelConstant),
+        ]
+        .iter()
+        .find(|x| x.0.starts_with(&str_.to_lowercase().replace("_", "")))
+        .map(|x| x.1.clone())
     }
 }
 

--- a/src/app_state/mod.rs
+++ b/src/app_state/mod.rs
@@ -95,6 +95,13 @@ impl AppState {
                     .complete((self.render_settings.prec, self.render_settings.prec));
             }
 
+            // Change the mandelbrot constant
+            if let Some(c) = saved.mandel_constant {
+                self.render_settings.mandel_constant = Complex::parse(c)
+                    .map_err(|err| format!("Invalid mandelbrot constant: {err}"))?
+                    .complete((self.render_settings.prec, self.render_settings.prec));
+            }
+
             // Change the julia constant
             if let Some(c) = saved.julia_constant {
                 self.render_settings.julia_constant = Complex::parse(c)

--- a/src/commands/capture.rs
+++ b/src/commands/capture.rs
@@ -55,6 +55,7 @@ pub(crate) fn execute_capture(state: &mut AppState, args: Vec<&str>) -> Result<(
 pub(crate) const CAPTURE: Command = Command {
     execute: &execute_capture,
     name: "capture",
+    aliases: &["cp"],
     accepted_arg_count: &[0, 2],
     detailed_desc: Some(concat!(
         "<green Usage: <command [width] [height]>>\n",

--- a/src/commands/capture_format.rs
+++ b/src/commands/capture_format.rs
@@ -27,6 +27,7 @@ pub(crate) fn execute_capture_format(state: &mut AppState, args: Vec<&str>) -> R
 pub(crate) const CAPTURE_FORMAT: Command = Command {
     execute: &execute_capture_format,
     name: "capture_format",
+    aliases: &["cf"],
     accepted_arg_count: &[0, 1],
 
     detailed_desc: Some(concat!(

--- a/src/commands/clear.rs
+++ b/src/commands/clear.rs
@@ -9,6 +9,7 @@ pub(crate) fn execute_clear(state: &mut AppState, _args: Vec<&str>) -> Result<()
 pub(crate) const CLEAR: Command = Command {
     execute: &execute_clear,
     name: "clear",
+    aliases: &["c"],
     accepted_arg_count: &[0],
     detailed_desc: None,
     basic_desc: "Clear all messages from the log panel.",

--- a/src/commands/click_mode.rs
+++ b/src/commands/click_mode.rs
@@ -34,6 +34,7 @@ pub(crate) fn execute_click_mode(state: &mut AppState, args: Vec<&str>) -> Resul
 pub(crate) const CLICK_MODE: Command = Command {
     execute: &execute_click_mode,
     name: "click_mode",
+    aliases: &["cm"],
     accepted_arg_count: &[0, 2],
     detailed_desc: Some(concat!(
         "<green Usage: <command [no args]>>\n",

--- a/src/commands/color.rs
+++ b/src/commands/color.rs
@@ -29,6 +29,7 @@ pub(crate) fn execute_color(state: &mut AppState, args: Vec<&str>) -> Result<(),
 pub(crate) const COLOR: Command = Command {
     execute: &execute_color,
     name: "color",
+    aliases: &[],
     accepted_arg_count: &[0, 1],
     detailed_desc: Some(concat!(
         "<green Usage: <command [color]>>\n",

--- a/src/commands/frac.rs
+++ b/src/commands/frac.rs
@@ -53,6 +53,7 @@ pub(crate) fn execute_frac(state: &mut AppState, args: Vec<&str>) -> Result<(), 
 pub(crate) const FRAC: Command = Command {
     execute: &execute_frac,
     name: "frac",
+    aliases: &["f"],
     accepted_arg_count: &[0, 1, 2],
     detailed_desc: Some(concat!(
         "<green Usage: <command [frac]>>\n",

--- a/src/commands/gpu.rs
+++ b/src/commands/gpu.rs
@@ -19,6 +19,7 @@ pub(crate) fn execute_gpu(state: &mut AppState, _args: Vec<&str>) -> Result<(), 
 pub(crate) const GPU: Command = Command {
     execute: &execute_gpu,
     name: "gpu",
+    aliases: &[],
     accepted_arg_count: &[0],
     detailed_desc: None,
     basic_desc: concat!(

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -1,4 +1,4 @@
-use super::{get_commands_list, get_commands_map, Command};
+use super::{get_command_by_name, get_commands_list, Command};
 use crate::AppState;
 
 pub(crate) fn execute_help(state: &mut AppState, args: Vec<&str>) -> Result<(), String> {
@@ -23,7 +23,23 @@ pub(crate) fn execute_help(state: &mut AppState, args: Vec<&str>) -> Result<(), 
             format!(
                 "{}\n<green Use <command help command_name> to get more info about a command.>",
                 get_commands_list()
-                    .map(|c| format!("- <acc {}>: {}", c.name, c.basic_desc))
+                    .map(|c| format!(
+                        "- <acc {}>{}: {}",
+                        c.name,
+                        if c.aliases.is_empty() {
+                            "".to_string()
+                        } else {
+                            format!(
+                                " ({})",
+                                c.aliases
+                                    .iter()
+                                    .map(|c| format!("<acc {c}>"))
+                                    .collect::<Vec<String>>()
+                                    .join(", ")
+                            )
+                        },
+                        c.basic_desc
+                    ))
                     .join("\n")
             ),
         );
@@ -32,7 +48,7 @@ pub(crate) fn execute_help(state: &mut AppState, args: Vec<&str>) -> Result<(), 
     }
 
     let command_name = args[0];
-    let command = get_commands_map().remove(command_name).ok_or(format!(
+    let command = get_command_by_name(command_name).ok_or(format!(
         concat!(
             "Command not found: <bgred,white {}>. ",
             "Use <command help> for an overview of available commands."
@@ -43,7 +59,13 @@ pub(crate) fn execute_help(state: &mut AppState, args: Vec<&str>) -> Result<(), 
     state.log_info_title(
         command.name,
         format!(
-            "{}\n{}",
+            "Aliases: {}\n{}\n{}",
+            command
+                .aliases
+                .iter()
+                .map(|name| format!("<acc {name}>"))
+                .collect::<Vec<String>>()
+                .join(", "),
             command.basic_desc,
             command.detailed_desc.unwrap_or_default()
         ),
@@ -53,6 +75,7 @@ pub(crate) fn execute_help(state: &mut AppState, args: Vec<&str>) -> Result<(), 
 pub(crate) const HELP: Command = Command {
     execute: &execute_help,
     name: "help",
+    aliases: &["h"],
     accepted_arg_count: &[0, 1],
     basic_desc: "Provide information about the available commands.",
     detailed_desc: None,

--- a/src/commands/load.rs
+++ b/src/commands/load.rs
@@ -91,6 +91,7 @@ pub(crate) fn execute_load(state: &mut AppState, args: Vec<&str>) -> Result<(), 
 pub(crate) const LOAD: Command = Command {
     execute: &execute_load,
     name: "load",
+    aliases: &["l"],
     accepted_arg_count: &[0, 1],
     detailed_desc: Some(concat!(
         "<green Usage: <command [no args]>>\n",

--- a/src/commands/max_iter.rs
+++ b/src/commands/max_iter.rs
@@ -20,6 +20,7 @@ pub(crate) fn execute_max_iter(state: &mut AppState, args: Vec<&str>) -> Result<
 pub(crate) const MAX_ITER: Command = Command {
     execute: &execute_max_iter,
     name: "max_iter",
+    aliases: &["mi"],
     accepted_arg_count: &[0, 1, 2],
 
     detailed_desc: Some(concat!(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::AppState;
 pub(crate) mod capture;
 pub(crate) mod capture_format;
@@ -28,6 +26,7 @@ pub(crate) struct Command {
     pub(crate) execute: CommandClos,
     /// The name of the command.
     pub(crate) name: &'static str,
+    pub(crate) aliases: &'static [&'static str],
     /// A basic description of the command.
     pub(crate) basic_desc: &'static str,
     /// An optional detailed description of the command.
@@ -58,7 +57,10 @@ pub(crate) fn get_commands_list() -> [&'static Command; 17] {
     ]
 }
 
-/// Returns a `HashMap` associating each command's name to itself.
-pub(crate) fn get_commands_map() -> HashMap<&'static str, &'static Command> {
-    HashMap::from(get_commands_list().map(|command| (command.name, command)))
+pub(crate) fn get_command_by_name(name: &str) -> Option<&'static Command> {
+    let name = name.to_lowercase();
+    get_commands_list()
+        .iter()
+        .find(|c| c.name == name || c.aliases.contains(&name.as_str()))
+        .map(|c| &**c)
 }

--- a/src/commands/move_dist.rs
+++ b/src/commands/move_dist.rs
@@ -14,6 +14,7 @@ pub(crate) fn execute_move_dist(state: &mut AppState, args: Vec<&str>) -> Result
 pub(crate) const MOVE_DIST: Command = Command {
     execute: &execute_move_dist,
     name: "move_dist",
+    aliases: &["md"],
     accepted_arg_count: &[0, 1, 2],
 
     detailed_desc: Some(concat!(

--- a/src/commands/pos.rs
+++ b/src/commands/pos.rs
@@ -51,6 +51,7 @@ pub(crate) fn execute_pos(state: &mut AppState, args: Vec<&str>) -> Result<(), S
 pub(crate) const POS: Command = Command {
     execute: &execute_pos,
     name: "pos",
+    aliases: &[],
     accepted_arg_count: &[0, 2],
     basic_desc: "View or set the position of the canvas in the complex plane.",
     detailed_desc: Some(concat!(

--- a/src/commands/prec.rs
+++ b/src/commands/prec.rs
@@ -19,6 +19,7 @@ pub(crate) fn execute_prec(state: &mut AppState, args: Vec<&str>) -> Result<(), 
 pub(crate) const PREC: Command = Command {
     execute: &execute_prec,
     name: "prec",
+    aliases: &[],
     accepted_arg_count: &[0, 1, 2],
 
     detailed_desc: Some(concat!(

--- a/src/commands/quit.rs
+++ b/src/commands/quit.rs
@@ -8,6 +8,7 @@ pub(crate) fn execute_quit(state: &mut AppState, _args: Vec<&str>) -> Result<(),
 pub(crate) const QUIT: Command = Command {
     execute: &execute_quit,
     name: "quit",
+    aliases: &["q"],
     accepted_arg_count: &[0],
     detailed_desc: None,
     basic_desc: "Exit from the state and return to your shell session.",

--- a/src/commands/save.rs
+++ b/src/commands/save.rs
@@ -32,6 +32,7 @@ pub(crate) fn execute_save(state: &mut AppState, args: Vec<&str>) -> Result<(), 
 pub(crate) const SAVE: Command = Command {
     execute: &execute_save,
     name: "save",
+    aliases: &[],
     accepted_arg_count: &[0, 1],
     detailed_desc: Some(concat!(
         "<green Usage: <command [file path]>>\n",

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -12,6 +12,7 @@ pub(crate) fn execute_version(state: &mut AppState, _args: Vec<&str>) -> Result<
 pub(crate) const VERSION_COMMAND: Command = Command {
     execute: &execute_version,
     name: "version",
+    aliases: &["v"],
     accepted_arg_count: &[0],
     detailed_desc: None,
     basic_desc: "Display the version number of Rsfrac.",

--- a/src/commands/zoom_factor.rs
+++ b/src/commands/zoom_factor.rs
@@ -32,6 +32,7 @@ pub(crate) fn execute_zoom_factor(state: &mut AppState, args: Vec<&str>) -> Resu
 pub(crate) const ZOOM_FACTOR: Command = Command {
     execute: &execute_zoom_factor,
     name: "zoom_factor",
+    aliases: &["zf"],
     accepted_arg_count: &[0, 1],
     basic_desc: "View or set the scaling factor used when zooming in or out the canvas.",
     detailed_desc: Some(concat!(

--- a/src/components/canvas.rs
+++ b/src/components/canvas.rs
@@ -74,6 +74,9 @@ impl<'a> Canvas<'a> {
             ClickMode::JuliaConstant => {
                 state.render_settings.julia_constant = state.render_settings.coord_to_c(canvas_pos)
             }
+            ClickMode::MandelConstant => {
+                state.render_settings.mandel_constant = state.render_settings.coord_to_c(canvas_pos)
+            }
         }
 
         state.request_redraw();

--- a/src/components/input.rs
+++ b/src/components/input.rs
@@ -8,7 +8,7 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Widget},
 };
 
-use crate::{commands::get_commands_map, helpers::Focus, AppState};
+use crate::{commands::get_command_by_name, helpers::Focus, AppState};
 use tui_input::backend::crossterm::EventHandler;
 
 pub(crate) struct Input<'a> {
@@ -60,7 +60,7 @@ impl<'a> Input<'a> {
 
         // The first argument is the command name
         let command_name = args.remove(0);
-        if let Some(command) = get_commands_map().get(command_name).copied() {
+        if let Some(command) = get_command_by_name(command_name) {
             state.log_raw(format!("<command \\> {}>", input));
             if !command.accepted_arg_count.contains(&args.len()) {
                 // If the number of provided arguments in not in the accepted argument

--- a/src/frac_logic/gpu_render.rs
+++ b/src/frac_logic/gpu_render.rs
@@ -16,6 +16,7 @@ pub(crate) struct ParamsBinding {
     cell_size: f32,
     y_offset: i32,
     julia_constant: [f32; 2],
+    mandel_constant: [f32; 2],
 }
 
 impl RenderSettings {
@@ -108,6 +109,10 @@ impl RenderSettings {
                         julia_constant: [
                             self.julia_constant.real().to_f32(),
                             self.julia_constant.imag().to_f32(),
+                        ],
+                        mandel_constant: [
+                            self.mandel_constant.real().to_f32(),
+                            self.mandel_constant.imag().to_f32(),
                         ],
                     }),
                     usage: wgpu::BufferUsages::UNIFORM,

--- a/src/frac_logic/render_settings.rs
+++ b/src/frac_logic/render_settings.rs
@@ -18,6 +18,7 @@ const DEFAULT_MAX_ITER: i32 = 128;
 const BLACK: Color = Color::Rgb(0, 0, 0);
 const WHITE: Color = Color::Rgb(255, 255, 255);
 const DEFAULT_JULIA_CONSTANT: (f32, f32) = (-9.9418604e-1, 2.61627e-1);
+const DEFAULT_MANDEL_CONSTANT: (f32, f32) = (0.0, 0.0);
 
 /// Used to group values related to fractal rendering logic.
 #[derive(Clone)]
@@ -42,6 +43,7 @@ pub(crate) struct RenderSettings {
     pub(crate) wgpu_state: WgpuState,
     pub(crate) image_format: ImageFormat,
     pub(crate) julia_constant: Complex,
+    pub(crate) mandel_constant: Complex,
 }
 
 impl Default for RenderSettings {
@@ -60,6 +62,7 @@ impl Default for RenderSettings {
             use_gpu: false,
             wgpu_state: WgpuState::default(),
             julia_constant: Complex::with_val(DEFAULT_PREC, DEFAULT_JULIA_CONSTANT),
+            mandel_constant: Complex::with_val(DEFAULT_PREC, DEFAULT_MANDEL_CONSTANT),
         }
     }
 }

--- a/src/frac_logic/shaders/burning_ship.wgsl
+++ b/src/frac_logic/shaders/burning_ship.wgsl
@@ -8,7 +8,10 @@ struct Params {
     y_offset: i32,
     julia_constant_real: f32,
     julia_constant_imag: f32,
+    mandel_constant_real: f32,
+    mandel_constant_imag: f32,
 }
+
 
 
 @group(0) @binding(0) var<storage, read_write> output_buf: array<i32>; 

--- a/src/frac_logic/shaders/julia.wgsl
+++ b/src/frac_logic/shaders/julia.wgsl
@@ -8,6 +8,8 @@ struct Params {
     y_offset: i32,
     julia_constant_real: f32,
     julia_constant_imag: f32,
+    mandel_constant_real: f32,
+    mandel_constant_imag: f32,
 }
 
 

--- a/src/frac_logic/shaders/mandelbrot.wgsl
+++ b/src/frac_logic/shaders/mandelbrot.wgsl
@@ -8,6 +8,8 @@ struct Params {
     y_offset: i32,
     julia_constant_real: f32,
     julia_constant_imag: f32,
+    mandel_constant_real: f32,
+    mandel_constant_imag: f32,
 }
 
 
@@ -41,11 +43,11 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 
 fn iterations(point: vec2<f32>) -> i32 {
     var iter: i32 = 0i;
-    var z: vec2<f32> = vec2<f32>(0f, 0f);
+    var z: vec2<f32> = vec2<f32>(params.mandel_constant_real, params.mandel_constant_imag);
 
     while length(z) < 2f && iter < params.max_iter {
         z = vec2<f32>(
-            z.x * z.x - z.y * z.y + point.x,
+            pow(z.x, 2f) - pow(z.y, 2f) + point.x,
             2f * z.x * z.y + point.y
         );
         iter = iter + 1i;

--- a/src/fractals/mandelbrot.rs
+++ b/src/fractals/mandelbrot.rs
@@ -15,9 +15,7 @@ fn get_mandelbrot(p: Complex, render_settings: &RenderSettings) -> i32 {
     let mut n: i32 = 0;
     // Current term of the series
 
-    // Todo: allow to change this
-    let mandelbrot_u0 = (0, 0);
-    let mut z: Complex = Complex::with_val(render_settings.prec, mandelbrot_u0);
+    let mut z: Complex = render_settings.mandel_constant.clone();
 
     // Compute the next term while z is not beyond 2
     // from the origin and the maximum divergence is not passed

--- a/src/helpers/saved_state.rs
+++ b/src/helpers/saved_state.rs
@@ -15,6 +15,7 @@ pub(crate) struct SavedState {
     pub(crate) max_iter: Option<i32>,
     pub(crate) void_fill: Option<VoidFill>,
     pub(crate) julia_constant: Option<String>,
+    pub(crate) mandel_constant: Option<String>,
 }
 
 impl From<&AppState> for SavedState {
@@ -29,6 +30,7 @@ impl From<&AppState> for SavedState {
             precision: Some(state.render_settings.prec),
             void_fill: Some(void_fills()[state.render_settings.void_fill_index].clone()),
             julia_constant: Some(state.render_settings.julia_constant.to_string()),
+            mandel_constant: Some(state.render_settings.mandel_constant.to_string()),
         }
     }
 }


### PR DESCRIPTION
- Match `ClickMode` with only beginning of name
- Allow custom mandelbrot constant
- Add mandelbrot constant to `SavedState`
- Add command aliases
- Help command: show command aliases