### PR TITLE
Add dynamic defaults based on gpu initialization

### DIFF
--- a/src/app/main_loop.rs
+++ b/src/app/main_loop.rs
@@ -20,6 +20,7 @@ impl App {
         self.app_state.initial_message();
         if let Err(err) = execute_gpu(&mut self.app_state, Default::default()) {
             self.app_state.log_error(err);
+            self.app_state.cpu_defaults();
         }
         while !self.app_state.quit {
             let start = Instant::now();

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 use crate::AppState;
 pub(crate) mod capture;
+pub(crate) mod capture_fit;
 pub(crate) mod capture_format;
 pub(crate) mod clear;
 pub(crate) mod click_mode;
@@ -8,7 +9,6 @@ pub(crate) mod command_increment;
 pub(crate) mod frac;
 pub(crate) mod gpu;
 pub(crate) mod help;
-pub(crate) mod capture_fit;
 pub(crate) mod load;
 pub(crate) mod max_iter;
 pub(crate) mod move_dist;

--- a/src/commands/prec.rs
+++ b/src/commands/prec.rs
@@ -12,6 +12,10 @@ pub(crate) fn execute_prec(state: &mut AppState, args: Vec<&str>) -> Result<(), 
         MIN_DECIMAL_PREC,
         MAX_DECIMAL_PREC,
     ) {
+        state.log_info(concat!(
+            "Arbitrary precision if not taken into account when GPU mode is enabled. ",
+            "You can disable GPU mode with the <command gpu> command."
+        ));
         state.set_decimal_prec(val);
     }
     Ok(())

--- a/src/components/canvas.rs
+++ b/src/components/canvas.rs
@@ -139,11 +139,21 @@ impl<'a> Canvas<'a> {
             // When S is pressed increase the cell size, which will zoom out of the canvas
             KeyCode::Char('s') => {
                 state.zoom(ZoomDirection::Out);
+
+                // TODO: mueheheeh
+                // state.render_settings.color_scheme_offset =
+                //     (state.render_settings.color_scheme_offset + 15) % 16;
+                //
                 state.request_redraw();
             }
             // When D is pressed decrease the cell size, which will zoom into the canvas
             KeyCode::Char('d') => {
                 state.zoom(ZoomDirection::In);
+
+                // TODO: mueheheeh
+                // state.render_settings.color_scheme_offset =
+                //     (state.render_settings.color_scheme_offset + 1) % 16;
+
                 state.request_redraw();
             }
             // decrease the decimal precision


### PR DESCRIPTION
- Add dynamic defaults based on gpu initialization
- Decrease default move distance and zoom factor for GPU mode (soothing)
- Move some `RenderSettings` logic back to the `RenderSettings` struct.
- Add `capture_fit` command
- Add message when changing precision in GPU 