### PR TITLE
Fix error in gpu rendering

### DIFF
--- a/src/app/main_loop.rs
+++ b/src/app/main_loop.rs
@@ -82,6 +82,7 @@ impl App {
                         SlaveMessage::JobFinished => {
                             job.finished = true;
                         }
+                        SlaveMessage::Warning(warn) => self.app_state.log_warn(warn),
                         SlaveMessage::SetMessage(message) => {
 
                             *self

--- a/src/commands/max_iter.rs
+++ b/src/commands/max_iter.rs
@@ -2,7 +2,7 @@ use super::{command_increment::command_increment, Command};
 use crate::AppState;
 
 pub(crate) const MIN_MAX_ITER: i32 = 8;
-pub(crate) const MAX_MAX_ITER: i32 = 10000;
+pub(crate) const MAX_MAX_ITER: i32 = 100000;
 
 pub(crate) fn execute_max_iter(state: &mut AppState, args: Vec<&str>) -> Result<(), String> {
     let val = command_increment(

--- a/src/frac_logic/fractal_logic.rs
+++ b/src/frac_logic/fractal_logic.rs
@@ -9,6 +9,8 @@ use rayon::prelude::*;
 use rug::ops::CompleteRound;
 use rug::{Complex, Float};
 
+use super::gpu_util::SendSlaveMessage;
+
 const INITIAL_CANVAS_WIDTH: i32 = 5;
 pub(crate) type DivergMatrix = Vec<Vec<i32>>;
 
@@ -39,19 +41,15 @@ impl RenderSettings {
 
                 // Send an update to the parent process,
                 // indicating that one line has been rendered.
-                if let Some(sender) = sender {
-                    sender.send(SlaveMessage::LineRender).unwrap();
-                }
+                sender.send(SlaveMessage::LineRender).unwrap();
 
                 line
             })
             .collect();
 
         // Send a message to the parent process indicating that the screenshot finished,
-        // and it should now wait for the result transfet throught the `JoinHandle`.
-        if let Some(sender) = sender {
-            sender.send(SlaveMessage::JobFinished).unwrap()
-        }
+        // and it should now wait for the result transfer through the `JoinHandle`.
+        sender.send(SlaveMessage::JobFinished).unwrap();
 
         div_matrix
     }

--- a/src/frac_logic/gpu_init.rs
+++ b/src/frac_logic/gpu_init.rs
@@ -4,7 +4,10 @@ use futures::executor;
 
 use crate::app::SlaveMessage;
 
-use super::{gpu_util::msg_send, RenderSettings};
+use super::{
+    gpu_util::{msg_send, SendSlaveMessage},
+    RenderSettings,
+};
 
 impl RenderSettings {
     /// Will initialize the global wgpu state synchronously, while sending status messages
@@ -88,11 +91,7 @@ impl RenderSettings {
             "burningship" => wgpu::include_wgsl!("../fractals/shaders/burning_ship.wgsl"),
             "julia" => wgpu::include_wgsl!("../fractals/shaders/julia.wgsl"),
             _ => {
-                if let Some(sender) = sender {
-                    sender
-                        .send(SlaveMessage::JobFinished)
-                        .map_err(|err| format!("Could not open message channel: {err}"))?;
-                }
+                sender.send(SlaveMessage::JobFinished)?;
                 return Err(format!(
                     "Fractal shader not yet implemented for: {}",
                     self.get_frac_obj().name,

--- a/src/frac_logic/render_settings.rs
+++ b/src/frac_logic/render_settings.rs
@@ -27,7 +27,7 @@ const DEFAULT_SMOOTHNESS: i32 = 7;
 const DEFAULT_BAILOUT: f32 = 2.0;
 
 /// Used to group values related to fractal rendering logic.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct RenderSettings {
     /// The size of one canvas cell.
     pub(crate) cell_size: Float,

--- a/src/helpers/markup.rs
+++ b/src/helpers/markup.rs
@@ -7,6 +7,7 @@ use tui_markup::generator::{ANSIStringsGenerator, RatatuiTextGenerator};
 
 const ACCENT_COLOR: MyOwnColorType = MyOwnColorType(162, 119, 255);
 const RED: MyOwnColorType = MyOwnColorType(255, 109, 109);
+const YELLOW: MyOwnColorType = MyOwnColorType(255, 183, 0);
 const GREEN: MyOwnColorType = MyOwnColorType(88, 224, 178);
 const DIM: MyOwnColorType = MyOwnColorType(42, 42, 42);
 const COMMAND_BG: MyOwnColorType = MyOwnColorType(34, 40, 39);
@@ -35,6 +36,8 @@ pub fn get_ansi_generator() -> ANSIStringsGenerator<impl Fn(&str) -> Option<ANSI
         "bgred" => Some(ANSIStyle::default().on(RED.into())),
         "red" => Some(ANSIStyle::default().fg(RED.into())),
         "green" => Some(ANSIStyle::default().fg(GREEN.into())),
+        "bgyellow" => Some(ANSIStyle::default().on(YELLOW.into())),
+        "yellow" => Some(ANSIStyle::default().fg(YELLOW.into())),
         "bggreen" => Some(ANSIStyle::default().fg(BLACK.into()).on(GREEN.into())),
         "command" => Some(
             ANSIStyle::default()
@@ -51,6 +54,8 @@ pub fn get_ratatui_generator() -> RatatuiTextGenerator<impl Fn(&str) -> Option<S
     RatatuiTextGenerator::new(|tag: &str| match tag {
         "acc" => Some(Style::default().fg(ACCENT_COLOR.into())),
         "bgacc" => Some(Style::default().bg(ACCENT_COLOR.into())),
+        "bgyellow" => Some(Style::default().bg(YELLOW.into())),
+        "yellow" => Some(Style::default().fg(YELLOW.into())),
         "bgred" => Some(Style::default().bg(RED.into())),
         "red" => Some(Style::default().fg(RED.into())),
         "green" => Some(Style::default().fg(GREEN.into())),

--- a/src/helpers/saved_state.rs
+++ b/src/helpers/saved_state.rs
@@ -1,4 +1,4 @@
-use crate::{frac_logic::RenderSettings, AppState};
+use crate::frac_logic::RenderSettings;
 use serde::{Deserialize, Serialize};
 use std::{fs::File, io::Write};
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -96,6 +96,10 @@ impl AppState {
     pub(crate) fn log_error(&mut self, message: impl Into<String>) {
         self.log_error_title("Error", message);
     }
+    /// Creates a new warning log message with the provided message and a fixed title.
+    pub(crate) fn log_warn(&mut self, message: impl Into<String>) {
+        self.log_warn_title("Warning", message);
+    }
 
     /// Creates a new success log message with the provided title and message.
     pub(crate) fn log_success_title(
@@ -108,6 +112,10 @@ impl AppState {
     /// Creates a new info log message with the provided title and message.
     pub(crate) fn log_info_title(&mut self, title: impl Into<String>, message: impl Into<String>) {
         self.log_raw(format!("<bgacc  {} >\n{}", title.into(), message.into()))
+    }
+    /// Creates a new warning log message with the provided title and message.
+    pub(crate) fn log_warn_title(&mut self, title: impl Into<String>, message: impl Into<String>) {
+        self.log_raw(format!("<bgyellow  {} >\n{}", title.into(), message.into()))
     }
     /// Creates a new error log message with the provided title and message.
     pub(crate) fn log_error_title(&mut self, title: impl Into<String>, message: impl Into<String>) {


### PR DESCRIPTION
- Create new slave message to output a warning
- Fix capture state saved using wrong `RenderSettings`
- Increase the maximum divergence from `10000` to `100000`
- Create a shortcut to send message only if `Option<Sender<_>>` is `Some(_)`
- Fix GPU job timeout not reported.... Issue on WGPU's end, a temporary fix has been implemented.
- Report chunk size during GPU render
- Add `bgyellow` and `yellow` tags
- Add `warn` log utilities